### PR TITLE
doc: react-native-marquee迁移至gitee前仓库信息及代码更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# @react-native-ohos/rntpc_react-native-marquee
+#  迁移声明
 
-This project is based on [react-native-marquee](https://github.com/kyo504/react-native-marquee)
+- 本仓库已迁移至 Gitee：[OpenHarmony-SIG/rntpc_react-native-marquee](https://gitee.com/openharmony-sig/rntpc_react-native-marquee)。
+- 包名已更改为 `@react-native-ohos/react-native-marquee`，支持直接从 npm 下载。
+- 更多详情请查阅新仓库的 README 文件。
+- 本仓库旧版本的文档已归档：[链接](/doc/zh-cn.md)
 
-## Documentation
+# Migration Announcement
 
-- [中文](https://gitee.com/react-native-oh-library/usage-docs/blob/master/zh-cn/react-native-marquee.md)
-
-- [English](https://gitee.com/react-native-oh-library/usage-docs/blob/master/en/react-native-marquee.md)
-
-## License
-
-This library is licensed under [The MIT License (MIT)](https://github.com/react-native-oh-library/react-native-marquee/blob/sig/LICENSE)
+- This repository has been migrated to Gitee: [OpenHarmony-SIG/rntpc_react-native-marquee](https://gitee.com/openharmony-sig/rntpc_react-native-marquee)
+- The package name has been changed to `@react-native-ohos/react-native-marquee` and is now available for direct download from npm.
+- For more details, please refer to the README in the new repository.
+- Archived documentation for versions in this repository can be found here: [Link](/doc/en.md)

--- a/README.md
+++ b/README.md
@@ -1,74 +1,13 @@
-# react-native-marquee
+# @react-native-ohos/rntpc_react-native-marquee
 
-A pure JavaScript marquee text component for react native.
+This project is based on [react-native-marquee](https://github.com/kyo504/react-native-marquee)
 
-## Installation
+## Documentation
 
-```
-npm install --save react-native-marquee
-or
-yarn add react-native-marquee
-```
+- [中文](https://gitee.com/react-native-oh-library/usage-docs/blob/master/zh-cn/react-native-marquee.md)
 
-## Usage
+- [English](https://gitee.com/react-native-oh-library/usage-docs/blob/master/en/react-native-marquee.md)
 
-```Javascript
-import React, { Component } from 'react';
-import { StyleSheet, View } from 'react-native';
-import MarqueeText from 'react-native-marquee';
+## License
 
-export default class MarqueeTextSample extends Component {
-  render() {
-    return (
-      <View style={styles.container}>
-        <MarqueeText
-          style={{ fontSize: 24 }}
-          speed={1}
-          marqueeOnStart={true}
-          loop={true}
-          delay={1000}
-        >
-          Lorem Ipsum is simply dummy text of the printing and typesetting industry and typesetting industry.
-        </MarqueeText>
-      </View>
-    );
-  }
-}
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-  },
-});
-```
-
-## Properties
-
-MarqueeText component basically inherits TextProps and the followings are additional ones: 
-
-| Prop              | Type     | Optional | Default | Description
-|-------------------|----------|----------|---------| -----------
-| marqueeOnStart    | boolean  | true     | true    | A flag whether to start marquee animation right after render
-| speed             | number   | true     | 1       | Speed calculated as pixels/second
-| loop              | boolean  | true     | true    | A flag whether to loop marquee animation or not
-| delay             | number   | true     | 0       | Duration to delay the animation after render, in milliseconds
-| onMarqueeComplete | function | true     | void    | A callback for when the marquee finishes animation and stops
-| consecutive       | boolean  | true     | false   | A flag to enable consecutive mode that imitates the default behavior of HTML marquee element. Does not take effect if loop is false
-
-## Methods
-
-These methods are optional, you can use the isOpen property instead
-
-| Prop    | Params | Description      |
-|:--------|:------:|:----------------:|
-| start   |   -    | Start animation  |
-| stop    |   -    | Stop animation   |
-
-## Contribution
-
-Do you have any idea or want to change something? Just open an issue. Contributions are always welcome.
-
-## Lisence
-
-[MIT Lisence](https://opensource.org/licenses/MIT)
+This library is licensed under [The MIT License (MIT)](https://github.com/react-native-oh-library/react-native-marquee/blob/sig/LICENSE)

--- a/doc/en.md
+++ b/doc/en.md
@@ -1,0 +1,108 @@
+> Template version: v0.2.2
+
+<p align="center">
+  <h1 align="center"> <code>react-native-marquee</code> </h1>
+</p>
+<p align="center">
+    <a href="https://github.com/kyo504/react-native-marquee/blob/master">
+        <img src="https://img.shields.io/badge/platforms-android%20|%20ios%20|%20harmony%20-lightgrey.svg" alt="Supported platforms" />
+    </a>
+    <a href="https://github.com/kyo504/react-native-marquee/blob/master/LICENSE">
+        <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License" />
+    </a>
+</p>
+
+
+> [!TIP] [GitHub address](https://github.com/react-native-oh-library/react-native-marquee)
+
+## Installation and Usage
+
+Find the matching version information in the release address of a third-party library: [@react-native-oh-tpl/react-native-marquee Releases](https://github.com/react-native-oh-library/react-native-marquee/releases).For older versions that are not published to npm, please refer to the [installation guide](/en/tgz-usage-en.md) to install the tgz package.
+
+Go to the project directory and execute the following instruction:
+
+
+
+
+#### **npm**
+
+```bash
+npm install @react-native-oh-tpl/react-native-marquee
+```
+
+#### **yarn**
+
+```bash
+yarn add @react-native-oh-tpl/react-native-marquee
+```
+
+<!-- tabs:end -->
+
+The following code shows the basic use scenario of the repository:
+
+> [!WARNING] The name of the imported repository remains unchanged.
+
+```tsx
+import React, { Component } from "react";
+import { StyleSheet, View } from "react-native";
+import MarqueeText from "react-native-marquee";
+
+export default class MarqueeTextSample extends Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <MarqueeText
+          style={{ fontSize: 24 }}
+          speed={1}
+          marqueeOnStart={true}
+          loop={true}
+          delay={1000}
+        >
+          Lorem Ipsum is simply dummy text of the printing and typesetting
+          industry and typesetting industry.
+        </MarqueeText>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+  },
+});
+```
+
+## Constraints
+
+### Compatibility
+
+To use this repository, you need to use the correct React-Native and RNOH versions. In addition, you need to use DevEco Studio and the ROM on your phone.
+
+Check the release version information in the release address of the third-party library:[@react-native-oh-tpl/react-native-marquee Releases](https://github.com/react-native-oh-library/react-native-marquee/releases)
+
+## Properties
+
+> [!TIP] The **Platform** column indicates the platform where the properties are supported in the original third-party library.
+
+> [!TIP] If the value of **HarmonyOS Support** is **yes**, it means that the HarmonyOS platform supports this property; **no** means the opposite; **partially** means some capabilities of this property are supported. The usage method is the same on different platforms and the effect is the same as that of iOS or Android.
+
+MarqueText组件基本上继承了[TextProps](https://reactnative.dev/docs/text)，以下是附加组件：
+
+| Name              | Type     | Optional | Default | Description                                                  | Platform | HarmonyOS Support |
+| ----------------- | -------- | -------- | ------- | ------------------------------------------------------------ | -------- | ----------------- |
+| marqueeOnStart    | boolean  | true     | true    | 是否在渲染后立即启动字幕动画的标志                           | All      | yes               |
+| speed             | number   | true     | 1       | 以像素/秒计算的速度                                          | All      | yes               |
+| loop              | boolean  | true     | true    | 是否循环字幕动画的标志                                       | All      | yes               |
+| delay             | number   | true     | 0       | 渲染后延迟动画的持续时间，以毫秒为单位                       | All      | yes               |
+| onMarqueeComplete | function | true     | void    | 字幕完成动画并停止时的回调                                   | All      | yes               |
+| consecutive       | boolean  | true     | false   | 一个标志，用于启用模仿HTML字幕元素默认行为的连续模式。如果循环为false，则不生效 | All      | yes               |
+
+## Known Issues
+
+## Others
+
+## License
+
+This project is licensed under [The MIT License (MIT)](https://github.com/kyo504/react-native-marquee/blob/master/LICENSE).

--- a/doc/zh-cn.md
+++ b/doc/zh-cn.md
@@ -1,0 +1,107 @@
+> 模板版本：v0.2.2
+
+<p align="center">
+  <h1 align="center"> <code>react-native-marquee</code> </h1>
+</p>
+<p align="center">
+    <a href="https://github.com/kyo504/react-native-marquee/blob/master">
+        <img src="https://img.shields.io/badge/platforms-android%20|%20ios%20|%20harmony%20-lightgrey.svg" alt="Supported platforms" />
+    </a>
+    <a href="https://github.com/kyo504/react-native-marquee/blob/master/LICENSE">
+        <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License" />
+    </a>
+</p>
+
+
+> [!TIP] [Github 地址](https://github.com/react-native-oh-library/react-native-marquee)
+
+## 安装与使用
+
+请到三方库的 Releases 发布地址查看配套的版本信息：[@react-native-oh-tpl/react-native-marquee Releases](https://github.com/react-native-oh-library/react-native-marquee/releases) 。对于未发布到npm的旧版本，请参考[安装指南](/zh-cn/tgz-usage.md)安装tgz包。
+
+进入到工程目录并输入以下命令：
+
+进入到工程目录并输入以下命令：
+
+#### **npm**
+
+```bash
+npm install @react-native-oh-tpl/react-native-marquee
+```
+
+#### **yarn**
+
+```bash
+yarn add @react-native-oh-tpl/react-native-marquee
+```
+
+<!-- tabs:end -->
+
+下面的代码展示了这个库的基本使用场景：
+
+> [!WARNING] 使用时 import 的库名不变。
+
+```tsx
+import React, { Component } from "react";
+import { StyleSheet, View } from "react-native";
+import MarqueeText from "react-native-marquee";
+
+export default class MarqueeTextSample extends Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <MarqueeText
+          style={{ fontSize: 24 }}
+          speed={1}
+          marqueeOnStart={true}
+          loop={true}
+          delay={1000}
+        >
+          Lorem Ipsum is simply dummy text of the printing and typesetting
+          industry and typesetting industry.
+        </MarqueeText>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+  },
+});
+```
+
+## 约束与限制
+
+### 兼容性
+
+要使用此库，需要使用正确的 React-Native 和 RNOH 版本。另外，还需要使用配套的 DevEco Studio 和 手机 ROM。
+
+请到三方库相应的 Releases 发布地址查看 Release 配套的版本信息：[@react-native-oh-tpl/react-native-marquee Releases](https://github.com/react-native-oh-library/react-native-marquee/releases)
+
+## 属性
+
+> [!TIP] "Platform"列表示该属性在原三方库上支持的平台。
+
+> [!TIP] "HarmonyOS Support"列为 yes 表示 HarmonyOS 平台支持该属性；no 则表示不支持；partially 表示部分支持。使用方法跨平台一致，效果对标 iOS 或 Android 的效果。
+
+MarqueText组件基本上继承了[TextProps](https://reactnative.dev/docs/text)，以下是附加组件：
+
+| Name              | Type     | Optional | Default | Description                                                  | Platform | HarmonyOS Support |
+| ----------------- | -------- | -------- | ------- | ------------------------------------------------------------ | -------- | ----------------- |
+| marqueeOnStart    | boolean  | true     | true    | 是否在渲染后立即启动字幕动画的标志                           | All      | yes               |
+| speed             | number   | true     | 1       | 以像素/秒计算的速度                                          | All      | yes               |
+| loop              | boolean  | true     | true    | 是否循环字幕动画的标志                                       | All      | yes               |
+| delay             | number   | true     | 0       | 渲染后延迟动画的持续时间，以毫秒为单位                       | All      | yes               |
+| onMarqueeComplete | function | true     | void    | 字幕完成动画并停止时的回调                                   | All      | yes               |
+| consecutive       | boolean  | true     | false   | 一个标志，用于启用模仿HTML字幕元素默认行为的连续模式。如果循环为false，则不生效 | All      | yes               |
+
+## 遗留问题
+
+## 其他
+
+## 开源协议
+
+本项目基于 [The MIT License (MIT)](https://github.com/kyo504/react-native-marquee/blob/master/LICENSE) ，请自由地享受和参与开源。


### PR DESCRIPTION
1. README 替换新模板
2. RN JS库删除空的 harmony 文件夹